### PR TITLE
evidently 0.3.3 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sfe1ed40
-channels:
-  - sfe1ed40
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - sfe1ed40
+upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ test:
   requires:
     - pip
     - pytest
+    - numba >=0.57.0
   commands:
     - pip check
     - pytest tests -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ test:
   requires:
     - pip
     - pytest
+    - ipython
     # To fix `from numba.np.ufunc import _internal SystemError: initialization of _internal failed without raising an exception`
     - numba >=0.57.0
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,10 +39,11 @@ test:
   imports:
     - evidently
   source_files:
-    - tests/*.py
+    - tests
   requires:
     - pip
     - pytest
+    # To fix `from numba.np.ufunc import _internal SystemError: initialization of _internal failed without raising an exception`
     - numba >=0.57.0
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "evidently" %}
 {% set version = "0.3.3" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -12,21 +11,23 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  # umap-learn isn't available on s390x
+  skip: True  # [py<37 or s390x]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - setuptools
+    - wheel
   run:
-    - dataclasses >=0.6
     - nltk >=3.6.7
     - numpy >=1.19.5
     - pandas >=1.3.5
     - plotly >=5.5.0
-    - pydantic <2
-    - python >=3.6
+    - pydantic >=1.9,<2
+    - python
     - pyyaml >=5.1
     - requests >=2.19.0
     - scikit-learn >=0.24.0
@@ -37,16 +38,26 @@ requirements:
 test:
   imports:
     - evidently
-  commands:
-    - pip check
+  source_files:
+    - tests/*.py
   requires:
     - pip
+    - pytest
+  commands:
+    - pip check
+    - pytest tests -vv
 
 about:
   home: https://github.com/evidentlyai/evidently
+  dev_url: https://github.com/evidentlyai/evidently
   doc_url: https://docs.evidentlyai.com/
   summary: Analyze, monitor, and debug machine learning model in production.
+  description: |
+    Evidently is an open-source Python library for data scientists and ML engineers. 
+    It helps evaluate, test, and monitor the performance of ML models from validation to production. 
+    It works with tabular, text data and embeddings.
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
 
 extra:


### PR DESCRIPTION
Changelog: https://github.com/evidentlyai/evidently/releases
License: https://github.com/evidentlyai/evidently/blob/v0.3.3/LICENSE
Requirements: 
- https://github.com/evidentlyai/evidently/blob/v0.3.3/requirements.min.txt
- https://github.com/evidentlyai/evidently/blob/v0.3.3/setup.cfg
- https://github.com/evidentlyai/evidently/blob/v0.3.3/setup.py

Actions:
1. Clean up the recipe:
- Remove `noarch` python
- Skip `py<37`
- Skip `s390x` as `umap-learn` isn't available on s390x
- Add flags `--no-deps --no-build-isolation` to `script`
- Add missing `setuptools` & `wheel` to `host`
- Fix `python` in `host` and `run`
2. Update runtime dependencies: remove `dataclasses >=0.6`, fix pin for `pydantic >=1.9,<2`
3. Add `numba >=0.57.0` to `test/requires` to fix `SystemError: initialization of _internal failed without raising an exception` caused by an incorrect version of `numba` or `numpy` in the test environment, see also https://stackoverflow.com/questions/74947992/how-to-remove-the-error-systemerror-initialization-of-internal-failed-without
4. Add a test suite: `source_files`, `pytest` and the pytest command, to check if there can be issues we are not aware
5. Add `dev_url`
6. Add a `description`
7. Add `license_family`